### PR TITLE
fix(key-events): use better supported key event properties

### DIFF
--- a/store/ui.js
+++ b/store/ui.js
@@ -33,9 +33,9 @@ module.exports = function (state, emitter) {
   })
   emitter.on('keydown', function (ev) {
     var m
-    if (ev.code === 'KeyR') emitter.emit('rotate-brick')
-    else if (ev.code === 'KeyD') emitter.emit('toggle-remove')
-    else if (m = /^Digit(\d+)$/.exec(ev.code)) {
+    if (ev.key === 'r') emitter.emit('rotate-brick')
+    else if (ev.key === 'd') emitter.emit('toggle-remove')
+    else if (m = /^(\d+)$/.exec(ev.key)) {
       if (state.colors[m[1]]) {
         emitter.emit('set-color', state.colors[m[1]])
         emitter.emit('frame')


### PR DESCRIPTION
# problem

- i cannot use key inputs as intended

# solution

- drop use of `evt.code`, swap for `evt.key`

> Be aware, however, that you can't use the value reported by KeyboardEvent.code to determine the character generated by the keystroke, because the keycode's name may not match the actual character that's printed on the key or that's generated by the computer when the key is pressed

[ref](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code)